### PR TITLE
Expand Godot GDScript matcher

### DIFF
--- a/apps/godot/godot.py
+++ b/apps/godot/godot.py
@@ -37,7 +37,7 @@ lang_ctx = Context()
 lang_ctx.matches = r"""
 app: godot
 not tag: user.code_language_forced
-win.title: /(?i)\.gd/
+win.title: /(?i)(\.gd|godot engine)/
 """
 
 


### PR DESCRIPTION
## Summary
- broaden the Godot GDScript language context to also match window titles containing "Godot Engine"

## Testing
- not run