### PR TITLE
Expand Godot voice commands

### DIFF
--- a/apps/godot/godot.talon
+++ b/apps/godot/godot.talon
@@ -3,3 +3,40 @@ app: godot
 
 play project: key(f5)
 play scene: key(f6)
+pause scene: key(f7)
+stop scene: key(f8)
+play custom scene: key(f9)
+
+add node: key(ctrl-a)
+duplicate node: key(ctrl-d)
+delete node: key(del)
+rename node: key(f2)
+move node up: key(ctrl-up)
+move node down: key(ctrl-down)
+
+save scene: key(ctrl-s)
+undo: key(ctrl-z)
+redo: key(ctrl-shift-z)
+copy: key(ctrl-c)
+cut: key(ctrl-x)
+paste: key(ctrl-v)
+find in files: key(ctrl-shift-f)
+
+toggle output: key(f12)
+toggle debugger: key(shift-f12)
+toggle animation: key(ctrl-f12)
+toggle audio: key(alt-f12)
+toggle import: key(ctrl-shift-f12)
+
+focus script editor: key(f11)
+switch to 2d: key(f1)
+switch to 3d: key(f2)
+switch to script: key(f3)
+switch to assetlib: key(f4)
+
+zoom in: key(ctrl-plus)
+zoom out: key(ctrl-minus)
+reset zoom: key(ctrl-0)
+
+search files: key(alt-shift-o)
+quick open scene: key(ctrl-shift-o)

--- a/lang/gdscript/gdscript.py
+++ b/lang/gdscript/gdscript.py
@@ -1,3 +1,5 @@
+from typing import Iterable, Optional
+
 from talon import Context, Module, actions, app, settings
 
 from ...core.described_functions import create_described_insert_between
@@ -62,6 +64,44 @@ def _insert_function(prefix: str, formatter_setting: str, text: str) -> None:
     actions.edit.left()
 
 
+def _format_name(text: str, formatter_setting: str) -> str:
+    return actions.user.formatted_text(text, settings.get(formatter_setting))
+
+
+def _format_variable_name(text: str) -> str:
+    return _format_name(text, "user.code_public_variable_formatter")
+
+
+def _format_constant_name(text: str) -> str:
+    return actions.user.formatted_text(text, "ALL_CAPS,SNAKE_CASE")
+
+
+def _format_signal_name(text: str) -> str:
+    return actions.user.formatted_text(text, "SNAKE_CASE")
+
+
+def _insert_parameter(name: str, type_name: Optional[str] = None) -> None:
+    formatted_name = _format_variable_name(name)
+    if type_name:
+        actions.insert(f"({formatted_name}: {type_name})")
+    else:
+        actions.insert(f"({formatted_name})")
+
+
+def _insert_variable(name: str, type_name: Optional[str] = None) -> None:
+    formatted_name = _format_variable_name(name)
+    if type_name:
+        actions.insert(f"var {formatted_name}: {type_name}")
+    else:
+        actions.insert(f"var {formatted_name}")
+
+
+def _insert_enum(name: str, values: Iterable[str]) -> None:
+    formatted_name = actions.user.formatted_text(name, "PUBLIC_CAMEL_CASE")
+    formatted_values = ", ".join(_format_constant_name(value) for value in values)
+    actions.insert(f"enum {formatted_name} {{ {formatted_values} }}")
+
+
 @ctx.action_class("user")
 class UserActions:
     def code_get_operators() -> Operators:
@@ -121,6 +161,148 @@ class UserActions:
 
     def code_insert_named_argument(parameter_name: str):
         actions.insert(f"{parameter_name}: ")
+
+    def gdscript_insert_parameter(text: str):
+        _insert_parameter(text)
+
+    def gdscript_insert_typed_parameter(name: str, type: str):
+        _insert_parameter(name, type)
+
+    def gdscript_insert_variable(text: str):
+        _insert_variable(text)
+
+    def gdscript_insert_typed_variable(name: str, type: str):
+        _insert_variable(name, type)
+
+    def gdscript_insert_export(name: str, type: str):
+        formatted_name = _format_variable_name(name)
+        actions.insert(f"@export var {formatted_name}: {type}")
+
+    def gdscript_insert_onready(name: str):
+        formatted_name = _format_variable_name(name)
+        actions.insert(f"@onready var {formatted_name}")
+
+    def gdscript_insert_constant(name: str, value: str):
+        formatted_name = _format_constant_name(name)
+        actions.insert(f"const {formatted_name} = {value}")
+
+    def gdscript_insert_signal(name: str):
+        formatted_name = _format_signal_name(name)
+        actions.insert(f"signal {formatted_name}")
+
+    def gdscript_emit_signal(name: str):
+        formatted_name = _format_signal_name(name)
+        actions.insert(f'emit_signal("{formatted_name}")')
+
+    def gdscript_connect_signal(name: str):
+        formatted_name = _format_signal_name(name)
+        actions.insert(f'.connect("{formatted_name}", self, "_on_{formatted_name}")')
+
+    def gdscript_on_signal(name: str):
+        formatted_name = _format_signal_name(name)
+        actions.insert(f"func _on_{formatted_name}(): pass")
+
+    def gdscript_insert_if(condition: str):
+        actions.insert(f"if {condition}:")
+
+    def gdscript_insert_elif(condition: str):
+        actions.insert(f"elif {condition}:")
+
+    def gdscript_insert_else():
+        actions.insert("else:")
+
+    def gdscript_insert_match(name: str):
+        actions.insert(f"match {name}:")
+
+    def gdscript_insert_for(variable: str, iterable: str):
+        actions.insert(f"for {variable} in {iterable}:")
+
+    def gdscript_insert_for_range(variable: str, maximum: str):
+        actions.insert(f"for {variable} in range({maximum}):")
+
+    def gdscript_insert_while(condition: str):
+        actions.insert(f"while {condition}:")
+
+    def gdscript_insert_lifecycle(name: str):
+        actions.insert(f"func _{name}():")
+
+    def gdscript_insert_process():
+        actions.insert("func _process(delta):")
+
+    def gdscript_insert_physics_process():
+        actions.insert("func _physics_process(delta):")
+
+    def gdscript_insert_input(event_name: str):
+        actions.insert(f"func _{event_name}(event):")
+
+    def gdscript_insert_array(values: Optional[str] = None):
+        if values:
+            actions.insert(f"[{values}]")
+        else:
+            actions.insert("[]")
+
+    def gdscript_insert_dictionary(pairs: Optional[str] = None):
+        if pairs:
+            actions.insert(f"{{{pairs}}}")
+        else:
+            actions.insert("{}")
+
+    def gdscript_insert_enum(name: str, values: str):
+        value_list = [value.strip(",") for value in values.split() if value.strip(",")]
+        _insert_enum(name, value_list)
+
+    def gdscript_assignment(name: str, value: str):
+        actions.insert(f"{name} = {value}")
+
+    def gdscript_increment(name: str):
+        actions.insert(f"{name} += 1")
+
+    def gdscript_decrement(name: str):
+        actions.insert(f"{name} -= 1")
+
+    def gdscript_random_int(minimum: str, maximum: str):
+        actions.insert(f"randi_range({minimum}, {maximum})")
+
+    def gdscript_random_float(minimum: str, maximum: str):
+        actions.insert(f"randf_range({minimum}, {maximum})")
+
+    def gdscript_randomize():
+        actions.insert("randomize()")
+
+    def gdscript_get_node(path: str):
+        actions.insert(f'get_node("{path}")')
+
+    def gdscript_add_child(node: str):
+        actions.insert(f"add_child({node})")
+
+    def gdscript_queue_free():
+        actions.insert("queue_free()")
+
+    def gdscript_is_instance_valid(name: str):
+        actions.insert(f"is_instance_valid({name})")
+
+    def gdscript_has_node(path: str):
+        actions.insert(f'has_node("{path}")')
+
+    def gdscript_return():
+        actions.insert("return")
+
+    def gdscript_pass():
+        actions.insert("pass")
+
+    def gdscript_print(text: str):
+        actions.insert(f"print({text})")
+
+    def gdscript_class_name(name: str):
+        formatted_name = actions.user.formatted_text(name, "PUBLIC_CAMEL_CASE")
+        actions.insert(f"class_name {formatted_name}")
+
+    def gdscript_extends(name: str):
+        formatted_name = actions.user.formatted_text(name, "PUBLIC_CAMEL_CASE")
+        actions.insert(f"extends {formatted_name}")
+
+    def gdscript_assert(condition: str):
+        actions.insert(f"assert({condition})")
 
     def code_try_catch():
         app.notify("GDScript does not support try/catch blocks")

--- a/lang/gdscript/gdscript.talon
+++ b/lang/gdscript/gdscript.talon
@@ -27,17 +27,175 @@ settings():
 # Sample commands
 # ---------------
 state extends <user.text>:
-    insert("extends ")
-    insert(user.formatted_text(text, "PUBLIC_CAMEL_CASE"))
+    user.gdscript_extends(text)
 
 state class name <user.text>:
-    insert("class_name ")
-    insert(user.formatted_text(text, "PUBLIC_CAMEL_CASE"))
+    user.gdscript_class_name(text)
 
 signal <user.text>:
-    insert("signal ")
-    insert(user.formatted_text(text, "SNAKE_CASE"))
+    user.gdscript_insert_signal(text)
 
 state on ready (var | variable) <user.text>:
-    insert("@onready var ")
-    user.code_public_variable_formatter(text)
+    user.gdscript_insert_onready(text)
+
+function <user.text>:
+    user.code_public_function(text)
+
+private function <user.text>:
+    user.code_private_function(text)
+
+static function <user.text>:
+    user.code_public_static_function(text)
+
+private static function <user.text>:
+    user.code_private_static_function(text)
+
+parameter <user.text>$:
+    user.gdscript_insert_parameter(text)
+
+parameter <user.text> <user.code_type>:
+    user.gdscript_insert_typed_parameter(text, code_type)
+
+return type <user.code_type>:
+    user.code_insert_return_type(code_type)
+
+variable <user.text>$:
+    user.gdscript_insert_variable(text)
+
+variable <user.text> <user.code_type>:
+    user.gdscript_insert_typed_variable(text, code_type)
+
+export int <user.text>:
+    user.gdscript_insert_export(text, "int")
+
+export float <user.text>:
+    user.gdscript_insert_export(text, "float")
+
+export bool <user.text>:
+    user.gdscript_insert_export(text, "bool")
+
+onready var <user.text>:
+    user.gdscript_insert_onready(text)
+
+const <user.text> = <user.text>:
+    user.gdscript_insert_constant(text, text_1)
+
+emit signal <user.text>:
+    user.gdscript_emit_signal(text)
+
+connect signal <user.text>:
+    user.gdscript_connect_signal(text)
+
+on signal <user.text>:
+    user.gdscript_on_signal(text)
+
+if <user.text>:
+    user.gdscript_insert_if(text)
+
+elif <user.text>:
+    user.gdscript_insert_elif(text)
+
+else:
+    user.gdscript_insert_else()
+
+match <user.text>:
+    user.gdscript_insert_match(text)
+
+for <user.text> in <user.text>:
+    user.gdscript_insert_for(text, text_1)
+
+for <user.text> in range <number>:
+    user.gdscript_insert_for_range(text, number)
+
+while <user.text>:
+    user.gdscript_insert_while(text)
+
+init:
+    user.gdscript_insert_lifecycle("init")
+
+ready:
+    user.gdscript_insert_lifecycle("ready")
+
+enter tree:
+    user.gdscript_insert_lifecycle("enter_tree")
+
+exit tree:
+    user.gdscript_insert_lifecycle("exit_tree")
+
+process:
+    user.gdscript_insert_process()
+
+physics process:
+    user.gdscript_insert_physics_process()
+
+input event:
+    user.gdscript_insert_input("input")
+
+unhandled input event:
+    user.gdscript_insert_input("unhandled_input")
+
+empty array:
+    user.gdscript_insert_array()
+
+array <user.text>:
+    user.gdscript_insert_array(text)
+
+empty dictionary:
+    user.gdscript_insert_dictionary()
+
+dictionary <user.text>:
+    user.gdscript_insert_dictionary(text)
+
+enum <user.text> <user.text>:
+    user.gdscript_insert_enum(text, text_1)
+
+set <user.text> equals <user.text>:
+    user.gdscript_assignment(text, text_1)
+
+increment <user.text>:
+    user.gdscript_increment(text)
+
+decrement <user.text>:
+    user.gdscript_decrement(text)
+
+random int <number> to <number>:
+    user.gdscript_random_int(number, number_1)
+
+random float <number> to <number>:
+    user.gdscript_random_float(number, number_1)
+
+randomize seed:
+    user.gdscript_randomize()
+
+get node <user.text>:
+    user.gdscript_get_node(text)
+
+add child <user.text>:
+    user.gdscript_add_child(text)
+
+queue free:
+    user.gdscript_queue_free()
+
+is instance valid <user.text>:
+    user.gdscript_is_instance_valid(text)
+
+has node <user.text>:
+    user.gdscript_has_node(text)
+
+return:
+    user.gdscript_return()
+
+pass:
+    user.gdscript_pass()
+
+print <user.text>:
+    user.gdscript_print(text)
+
+class name <user.text>:
+    user.gdscript_class_name(text)
+
+extends <user.text>:
+    user.gdscript_extends(text)
+
+assert <user.text>:
+    user.gdscript_assert(text)


### PR DESCRIPTION
## Summary
- add extensive GDScript snippets for functions, parameters, variables, signals, control flow, lifecycle hooks, collections, enums, and utilities
- wire scene-tree helpers, random generators, and misc snippets through new user actions for formatting and reuse
- expand the Godot app grammar with play/debug keys, tree management, editing shortcuts, panels, navigation, zoom, and file search commands

## Testing
- python -m compileall lang/gdscript