### PR TITLE
Add installation and testing docs for Godot support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,39 @@
+# Installation Guide for Talon Godot Support
+
+## Prerequisites
+- Talon Voice installed on the system.
+- Godot Engine installed (version 4+).
+- Optional: Visual Studio Code if editing scripts outside of Godot.
+
+## Installation
+1. Clone this repository (or download as ZIP) into the Talon user directory:
+   - Windows: %APPDATA%\Talon\user
+   - macOS: ~/.talon/user
+   - Linux: ~/.talon/user
+2. Ensure the folder is named something recognizable like `talon-godot-support`.
+
+## Usage
+1. Open Godot and/or VSCode.
+2. Voice commands in `.gd` files will trigger GDScript snippets.
+3. Voice commands while the Godot editor is active will trigger editor shortcuts.
+
+## Examples
+- Say: "function jump" → inserts:
+  ```gdscript
+  func jump():
+  ```
+- Say: "signal health changed" → inserts:
+  ```gdscript
+  signal health_changed
+  ```
+- Say: "play scene" → triggers F6 in Godot editor.
+
+## Updating
+- Pull latest changes from GitHub if updates are released.
+- Restart Talon after updates.
+
+## Notes
+- Default Godot shortcuts are assumed (from the Godot documentation).
+- If shortcuts are customized in Godot, update the corresponding `.talon` files.
+
+After installation, follow the [Testing guide](lang/gdscript/TESTING.md) to verify GDScript and Godot support.

--- a/lang/gdscript/TESTING.md
+++ b/lang/gdscript/TESTING.md
@@ -1,0 +1,33 @@
+# Testing Godot and GDScript Support
+This checklist covers only the Godot editor commands and GDScript language snippets added in this fork. For other languages (Python, C#, etc.), refer to the upstream community repo.
+
+## GDScript Commands
+- `function jump` → `func jump():`
+- `private function update` → `func _update():`
+- `variable health int` → `var health: int`
+- `export int speed` → `@export var speed: int`
+- `signal pressed` → `signal pressed`
+- `emit signal pressed` → `emit_signal("pressed")`
+- `on signal pressed` → `func _on_pressed(): pass`
+- `enum state idle running jumping` → `enum State { IDLE, RUNNING, JUMPING }`
+- `random int one to ten` → `randi_range(1, 10)`
+- `enter tree` → `func _enter_tree():`
+
+## Godot Editor Commands
+- `play project` → F5
+- `play scene` → F6
+- `pause scene` → F7
+- `stop scene` → F8
+- `add node` → Ctrl+A
+- `duplicate node` → Ctrl+D
+- `delete node` → Delete
+- `save scene` → Ctrl+S
+- `undo` → Ctrl+Z
+- `redo` → Ctrl+Shift+Z
+- `toggle output` → F12
+- `toggle debugger` → Shift+F12
+- `switch to 2D` → F1
+- `switch to 3D` → F2
+- `zoom in` → Ctrl+Plus
+- `zoom out` → Ctrl+Minus
+- `reset zoom` → Ctrl+0


### PR DESCRIPTION
## Summary
- add an INSTALL guide covering prerequisites, setup, usage, and notes for the Godot Talon profile
- provide a manual checklist for validating GDScript snippets and Godot editor commands

## Testing
- not run