### PR TITLE
Fix GDScript random range capture and enum formatting

### DIFF
--- a/lang/gdscript/TESTING.md
+++ b/lang/gdscript/TESTING.md
@@ -11,6 +11,7 @@ This checklist covers only the Godot editor commands and GDScript language snipp
 - `on signal pressed` → `func _on_pressed(): pass`
 - `enum state idle running jumping` → `enum State { IDLE, RUNNING, JUMPING }`
 - `random int one to ten` → `randi_range(1, 10)`
+- `random float zero point five to two point five` → `randf_range(0.5, 2.5)`
 - `enter tree` → `func _enter_tree():`
 
 ## Godot Editor Commands

--- a/lang/gdscript/gdscript.py
+++ b/lang/gdscript/gdscript.py
@@ -116,8 +116,16 @@ def _insert_export(name: str, type_name: Optional[str] = None) -> None:
 
 def _insert_enum(name: str, values: Iterable[str]) -> None:
     formatted_name = actions.user.formatted_text(name, "PUBLIC_CAMEL_CASE")
-    formatted_values = ", ".join(_format_constant_name(value) for value in values)
-    actions.insert(f"enum {formatted_name} {{ {formatted_values} }}")
+    formatted_values = [
+        _format_constant_name(value)
+        for value in values
+        if value
+    ]
+    if formatted_values:
+        joined_values = ", ".join(formatted_values)
+        actions.insert(f"enum {formatted_name} {{ {joined_values} }}")
+    else:
+        actions.insert(f"enum {formatted_name} {{}}")
 
 
 def _get_type_lookup() -> dict[str, str]:
@@ -332,9 +340,41 @@ class UserActions:
         else:
             actions.insert("{}")
 
-    def gdscript_insert_enum(name: str, values: str):
-        value_list = [value.strip(",") for value in values.split() if value.strip(",")]
-        _insert_enum(name, value_list)
+    def gdscript_insert_enum(words: str):
+        parts = [part.strip(",") for part in words.split() if part.strip(",")]
+        if not parts:
+            return
+
+        lowered = [part.lower() for part in parts]
+        split_index = next(
+            (index for index, token in enumerate(lowered) if token in {"with", "values"}),
+            None,
+        )
+
+        if split_index is not None and split_index > 0:
+            name_parts = parts[:split_index]
+            raw_values = parts[split_index + 1 :]
+        else:
+            name_parts = parts[:1]
+            raw_values = parts[1:]
+
+        name = " ".join(name_parts)
+        if any(token.lower() in {"and", "comma"} for token in raw_values):
+            grouped_values = []
+            current: list[str] = []
+            for token in raw_values:
+                if token.lower() in {"and", "comma"}:
+                    if current:
+                        grouped_values.append(" ".join(current))
+                        current = []
+                else:
+                    current.append(token)
+            if current:
+                grouped_values.append(" ".join(current))
+        else:
+            grouped_values = raw_values
+
+        _insert_enum(name, grouped_values)
 
     def gdscript_assignment(name: str, value: str):
         actions.insert(f"{name} = {value}")
@@ -505,7 +545,7 @@ class GDScriptActions:
         """Insert a dictionary literal, optionally populated with pairs."""
         pass
 
-    def gdscript_insert_enum(name: str, values: str):
+    def gdscript_insert_enum(words: str):
         """Insert an enum declaration with the provided members."""
         pass
 

--- a/lang/gdscript/gdscript.talon
+++ b/lang/gdscript/gdscript.talon
@@ -159,8 +159,8 @@ empty dictionary:
 dictionary <user.text>:
     user.gdscript_insert_dictionary(text)
 
-enum <user.text> <user.text>:
-    user.gdscript_insert_enum(text, text_1)
+enum <user.text>:
+    user.gdscript_insert_enum(text)
 
 set <user.text> equals <user.text>:
     user.gdscript_assignment(text, text_1)
@@ -171,11 +171,12 @@ increment <user.text>:
 decrement <user.text>:
     user.gdscript_decrement(text)
 
+# Talon numbers repeated captures starting at number_1/number_2.
 random int <number> to <number>:
-    user.gdscript_random_int(number, number_1)
+    user.gdscript_random_int(number_1, number_2)
 
-random float <number> to <number>:
-    user.gdscript_random_float(number, number_1)
+random float <user.number_prose_unprefixed> to <user.number_prose_unprefixed>:
+    user.gdscript_random_float(number_prose_unprefixed, number_prose_unprefixed_1)
 
 randomize seed:
     user.gdscript_randomize()


### PR DESCRIPTION
## Summary
- fix the GDScript random range commands by using the correct Talon capture slots and accepting decimal ranges for floats
- rework the enum command parsing so spoken names and members format correctly, including optional "with/values" separators
- document the decimal random float example in the testing checklist

## Testing
- python -m compileall lang/gdscript/gdscript.py