### PR TITLE
Fix GDScript random float range parsing

### DIFF
--- a/core/numbers/numbers.py
+++ b/core/numbers/numbers.py
@@ -281,6 +281,16 @@ def number_prose_with_colon(m) -> str:
     rule="<user.number_signed_string> | <user.number_prose_with_dot> | <user.number_prose_with_comma> | <user.number_prose_with_colon>"
 )
 def number_prose_unprefixed(m) -> str:
+    for attribute in (
+        "number_signed_string",
+        "number_prose_with_dot",
+        "number_prose_with_comma",
+        "number_prose_with_colon",
+    ):
+        value = getattr(m, attribute, None)
+        if value is not None:
+            return value
+
     return m[0]
 
 

--- a/lang/gdscript/TESTING.md
+++ b/lang/gdscript/TESTING.md
@@ -11,6 +11,7 @@ This checklist covers only the Godot editor commands and GDScript language snipp
 - `on signal pressed` → `func _on_pressed(): pass`
 - `enum state idle running jumping` → `enum State { IDLE, RUNNING, JUMPING }`
 - `random int one to ten` → `randi_range(1, 10)`
+- `random float one to three` → `randf_range(1, 3)`
 - `random float zero point five to two point five` → `randf_range(0.5, 2.5)`
 - `enter tree` → `func _enter_tree():`
 

--- a/test/test_gdscript_random_float.py
+++ b/test/test_gdscript_random_float.py
@@ -1,0 +1,72 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import talon
+
+
+if hasattr(talon, "test_mode"):
+    from unittest.mock import MagicMock
+
+    from talon import actions
+
+    from core.numbers import numbers
+
+    PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+    def _ensure_namespace_package(name: str, path: Path) -> None:
+        if name in sys.modules:
+            return
+
+        module = types.ModuleType(name)
+        module.__path__ = [str(path)]
+        sys.modules[name] = module
+
+
+    _ensure_namespace_package("talon_community", PROJECT_ROOT)
+    _ensure_namespace_package("talon_community.lang", PROJECT_ROOT / "lang")
+    _ensure_namespace_package("talon_community.core", PROJECT_ROOT / "core")
+    _ensure_namespace_package("talon_community.lang.gdscript", PROJECT_ROOT / "lang" / "gdscript")
+
+    gdscript_module = importlib.import_module("talon_community.lang.gdscript.gdscript")
+
+
+    class FakeMatch(list):
+        def __init__(self, first_value, **attributes):
+            super().__init__([first_value])
+            for name, value in attributes.items():
+                setattr(self, name, value)
+
+
+    def setup_function():
+        actions.reset_test_actions()
+
+
+    def _assert_randf_range(minimum_match: FakeMatch, maximum_match: FakeMatch, expected: str) -> None:
+        mock_insert = MagicMock()
+        actions.register_test_action("", "insert", mock_insert)
+
+        minimum = numbers.number_prose_unprefixed(minimum_match)
+        maximum = numbers.number_prose_unprefixed(maximum_match)
+
+        gdscript_module.UserActions.gdscript_random_float(minimum, maximum)
+
+        mock_insert.assert_called_once_with(expected)
+
+
+    def test_random_float_integers():
+        _assert_randf_range(
+            FakeMatch("1", number_signed_string="1"),
+            FakeMatch("1", number_signed_string="3"),
+            "randf_range(1, 3)",
+        )
+
+
+    def test_random_float_decimals():
+        _assert_randf_range(
+            FakeMatch("0.5", number_prose_with_dot="0.5"),
+            FakeMatch("0.5", number_prose_with_dot="2.5"),
+            "randf_range(0.5, 2.5)",
+        )


### PR DESCRIPTION
## Summary
- ensure `number_prose_unprefixed` prefers named match attributes so repeated float ranges capture both values
- add a GDScript random float test suite covering integer and decimal ranges
- extend the GDScript testing checklist to mention the integer-range command

## Testing
- pytest