### PR TITLE
Fix repeated number prose capture handling for random float

### DIFF
--- a/core/numbers/numbers.py
+++ b/core/numbers/numbers.py
@@ -281,13 +281,37 @@ def number_prose_with_colon(m) -> str:
     rule="<user.number_signed_string> | <user.number_prose_with_dot> | <user.number_prose_with_comma> | <user.number_prose_with_colon>"
 )
 def number_prose_unprefixed(m) -> str:
+    """Return the resolved string for a prose number capture.
+
+    Talon appends numeric suffixes (``_1``, ``_2`` …) when a capture is
+    repeated in a single rule.  The match object that is passed to each
+    capture function only exposes the suffixed attribute, so we need to look
+    for either the plain attribute name or any suffixed variant in order to
+    retrieve the resolved value.  Otherwise repeated captures would fall back
+    to ``m[0]`` which still contains the first capture's text.
+    """
+
+    def _get_attribute(base_name: str) -> str | None:
+        value = getattr(m, base_name, None)
+        if value is not None:
+            return value
+
+        prefixed = f"{base_name}_"
+        for name in dir(m):
+            if name.startswith(prefixed) and name[len(prefixed) :].isdigit():
+                value = getattr(m, name, None)
+                if value is not None:
+                    return value
+
+        return None
+
     for attribute in (
         "number_signed_string",
         "number_prose_with_dot",
         "number_prose_with_comma",
         "number_prose_with_colon",
     ):
-        value = getattr(m, attribute, None)
+        value = _get_attribute(attribute)
         if value is not None:
             return value
 

--- a/test/test_gdscript_random_float.py
+++ b/test/test_gdscript_random_float.py
@@ -56,6 +56,12 @@ if hasattr(talon, "test_mode"):
         mock_insert.assert_called_once_with(expected)
 
 
+    def test_number_prose_unprefixed_supports_repeated_captures():
+        match = FakeMatch("WRONG", number_prose_with_dot_1="2.5")
+
+        assert numbers.number_prose_unprefixed(match) == "2.5"
+
+
     def test_random_float_integers():
         _assert_randf_range(
             FakeMatch("1", number_signed_string="1"),
@@ -66,7 +72,7 @@ if hasattr(talon, "test_mode"):
 
     def test_random_float_decimals():
         _assert_randf_range(
-            FakeMatch("0.5", number_prose_with_dot="0.5"),
-            FakeMatch("0.5", number_prose_with_dot="2.5"),
+            FakeMatch("WRONG", number_prose_with_dot="0.5"),
+            FakeMatch("WRONG", number_prose_with_dot_1="2.5"),
             "randf_range(0.5, 2.5)",
         )


### PR DESCRIPTION
## Summary
- handle suffixed capture attributes in number_prose_unprefixed so repeated captures resolve distinct values
- add regression coverage proving gdscript random float uses distinct min and max when decimals are spoken

## Testing
- pytest