### PR TITLE
Fix GDScript random float capture naming

### DIFF
--- a/core/numbers/numbers.py
+++ b/core/numbers/numbers.py
@@ -277,19 +277,8 @@ def number_prose_with_colon(m) -> str:
     return ":".join(m.number_string_list)
 
 
-@mod.capture(
-    rule="<user.number_signed_string> | <user.number_prose_with_dot> | <user.number_prose_with_comma> | <user.number_prose_with_colon>"
-)
-def number_prose_unprefixed(m) -> str:
-    """Return the resolved string for a prose number capture.
-
-    Talon appends numeric suffixes (``_1``, ``_2`` …) when a capture is
-    repeated in a single rule.  The match object that is passed to each
-    capture function only exposes the suffixed attribute, so we need to look
-    for either the plain attribute name or any suffixed variant in order to
-    retrieve the resolved value.  Otherwise repeated captures would fall back
-    to ``m[0]`` which still contains the first capture's text.
-    """
+def _resolve_number_prose_unprefixed(m) -> str:
+    """Return the resolved string for a prose number capture."""
 
     def _get_attribute(base_name: str) -> str | None:
         value = getattr(m, base_name, None)
@@ -316,6 +305,37 @@ def number_prose_unprefixed(m) -> str:
             return value
 
     return m[0]
+
+
+@mod.capture(
+    rule="<user.number_signed_string> | <user.number_prose_with_dot> | <user.number_prose_with_comma> | <user.number_prose_with_colon>"
+)
+def number_prose_unprefixed(m) -> str:
+    """Return the resolved string for a prose number capture.
+
+    Talon appends numeric suffixes (``_1``, ``_2`` …) when a capture is
+    repeated in a single rule.  The match object that is passed to each
+    capture function only exposes the suffixed attribute, so we need to look
+    for either the plain attribute name or any suffixed variant in order to
+    retrieve the resolved value.  Otherwise repeated captures would fall back
+    to ``m[0]`` which still contains the first capture's text.
+    """
+
+    return _resolve_number_prose_unprefixed(m)
+
+
+@mod.capture(rule="<user.number_prose_unprefixed>")
+def number_prose_unprefixed_first(m) -> str:
+    """Resolve the first prose number in a repeated capture."""
+
+    return _resolve_number_prose_unprefixed(m)
+
+
+@mod.capture(rule="<user.number_prose_unprefixed>")
+def number_prose_unprefixed_second(m) -> str:
+    """Resolve the second prose number in a repeated capture."""
+
+    return _resolve_number_prose_unprefixed(m)
 
 
 @mod.capture(rule="(numb | numeral) <user.number_prose_unprefixed>")

--- a/lang/gdscript/gdscript.talon
+++ b/lang/gdscript/gdscript.talon
@@ -175,8 +175,8 @@ decrement <user.text>:
 random int <number> to <number>:
     user.gdscript_random_int(number_1, number_2)
 
-random float <user.number_prose_unprefixed> to <user.number_prose_unprefixed>:
-    user.gdscript_random_float(number_prose_unprefixed, number_prose_unprefixed_1)
+random float <user.number_prose_unprefixed_first> to <user.number_prose_unprefixed_second>:
+    user.gdscript_random_float(number_prose_unprefixed_first, number_prose_unprefixed_second)
 
 randomize seed:
     user.gdscript_randomize()

--- a/test/test_gdscript_random_float.py
+++ b/test/test_gdscript_random_float.py
@@ -48,8 +48,8 @@ if hasattr(talon, "test_mode"):
         mock_insert = MagicMock()
         actions.register_test_action("", "insert", mock_insert)
 
-        minimum = numbers.number_prose_unprefixed(minimum_match)
-        maximum = numbers.number_prose_unprefixed(maximum_match)
+        minimum = numbers.number_prose_unprefixed_first(minimum_match)
+        maximum = numbers.number_prose_unprefixed_second(maximum_match)
 
         gdscript_module.UserActions.gdscript_random_float(minimum, maximum)
 
@@ -65,7 +65,7 @@ if hasattr(talon, "test_mode"):
     def test_random_float_integers():
         _assert_randf_range(
             FakeMatch("1", number_signed_string="1"),
-            FakeMatch("1", number_signed_string="3"),
+            FakeMatch("WRONG", number_signed_string_1="3"),
             "randf_range(1, 3)",
         )
 
@@ -76,3 +76,11 @@ if hasattr(talon, "test_mode"):
             FakeMatch("WRONG", number_prose_with_dot_1="2.5"),
             "randf_range(0.5, 2.5)",
         )
+
+
+    def test_number_prose_unprefixed_wrappers_support_repeated_captures():
+        first = FakeMatch("WRONG", number_prose_with_dot="0.5")
+        second = FakeMatch("WRONG", number_prose_with_dot_1="2.5")
+
+        assert numbers.number_prose_unprefixed_first(first) == "0.5"
+        assert numbers.number_prose_unprefixed_second(second) == "2.5"


### PR DESCRIPTION
## Summary
- share the prose number resolution helper and expose dedicated first/second captures for repeated floats
- update the GDScript random float rule to call the new captures so minimum and maximum values stay distinct
- extend the GDScript random float tests to cover integer and decimal ranges using the new capture helpers

## Testing
- pytest test/test_gdscript_random_float.py